### PR TITLE
Renamed package to ckeditor5-editor-classic.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,7 +1,7 @@
-Creator Classic Changelog
+Classic Editor Changelog
 ========================================
 
-## Creator Classic 0.0.2
+## Classic Editor 0.0.2
 
 **Major|Minor|Patch Release** - Build Date: yyyy-mm-dd
 
@@ -20,6 +20,6 @@ Other Changes:
 * Item 1
 * Item 2
 
-## Creator Classic 0.0.1
+## Classic Editor 0.0.1
 
 ...

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,7 +1,7 @@
 Software License Agreement
 ==========================
 
-**Creator Classic** – https://github.com/ckeditor/ckeditor5-creator-classic <br>
+**Classic Editor** – https://github.com/ckeditor/ckeditor5-editor-classic <br>
 Copyright (c) 2003-2016, [CKSource](http://cksource.com) Frederico Knabben. All rights reserved.
 
 Licensed under the terms of any of the following licenses at your choice:

--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
-Creator Classic
+Classic Editor
 ========================================
 
-[![devDependency Status](https://david-dm.org/ckeditor/ckeditor5-creator-classic/dev-status.svg)](https://david-dm.org/ckeditor/ckeditor5-creator-classic#info=devDependencies)
+[![devDependency Status](https://david-dm.org/ckeditor/ckeditor5-editor-classic/dev-status.svg)](https://david-dm.org/ckeditor/ckeditor5-editor-classic#info=devDependencies)
 
-Classic Creator for CKEditor 5. More information about the project can be found at the following url: <https://github.com/ckeditor/ckeditor5-creator-classic>.
+Classic Editor for CKEditor 5. More information about the project can be found at the following url: <https://github.com/ckeditor/ckeditor5-editor-classic>.
 
 ## License
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "ckeditor5-creator-classic",
+  "name": "ckeditor5-editor-classic",
   "version": "0.0.1",
-  "description": "Classic Creator for CKEditor 5.",
+  "description": "Classic Editor for CKEditor 5.",
   "keywords": [],
   "dependencies": {},
   "devDependencies": {

--- a/tests/classic.js
+++ b/tests/classic.js
@@ -7,12 +7,12 @@
 
 'use strict';
 
-import ClassicEditorUI from '/ckeditor5/creator-classic/classiceditorui.js';
+import ClassicEditorUI from '/ckeditor5/editor-classic/classiceditorui.js';
 import BoxedEditorUIView from '/ckeditor5/ui/editorui/boxed/boxededitoruiview.js';
 
 import HtmlDataProcessor from '/ckeditor5/engine/dataprocessor/htmldataprocessor.js';
 
-import ClassicEditor from '/ckeditor5/creator-classic/classic.js';
+import ClassicEditor from '/ckeditor5/editor-classic/classic.js';
 
 import testUtils from '/tests/ckeditor5/_utils/utils.js';
 import count from '/ckeditor5/utils/count.js';

--- a/tests/classiceditorui.js
+++ b/tests/classiceditorui.js
@@ -7,7 +7,7 @@
 
 'use strict';
 
-import ClassicEditorUI from '/ckeditor5/creator-classic/classiceditorui.js';
+import ClassicEditorUI from '/ckeditor5/editor-classic/classiceditorui.js';
 import BoxedEditorUIView from '/ckeditor5/ui/editorui/boxed/boxededitoruiview.js';
 
 import Toolbar from '/ckeditor5/ui/toolbar/toolbar.js';

--- a/tests/manual/classic.js
+++ b/tests/manual/classic.js
@@ -7,7 +7,7 @@
 
 'use strict';
 
-import ClassicEditor from '/ckeditor5/creator-classic/classic.js';
+import ClassicEditor from '/ckeditor5/editor-classic/classic.js';
 import testUtils from '/tests/utils/_utils/utils.js';
 
 let editor, editable, observer;


### PR DESCRIPTION
Fixes #12.