### PR TITLE
Fixed hardcoded class name in static create method

### DIFF
--- a/src/classic.js
+++ b/src/classic.js
@@ -81,7 +81,7 @@ export default class ClassicEditor extends StandardEditor {
 	 */
 	static create( element, config ) {
 		return new Promise( ( resolve ) => {
-			const editor = new ClassicEditor( element, config );
+			const editor = new this( element, config );
 
 			resolve(
 				editor.initPlugins()


### PR DESCRIPTION
Same as `StandardEditor.create` and `Editor.create` do, `ClassicEditor.create` must call `new this(...)` rather than hardcoded `new ClassicEditor(...)`.

Otherwise, a class inherited from `ClassicEditor` can not be instantiated with `MyClassicEditor.create`.