### PR TITLE
t/51: Used getItemsFromConfig to bootstrap the toolbar in ClassicEditorUI.

### DIFF
--- a/src/classiceditorui.js
+++ b/src/classiceditorui.js
@@ -9,7 +9,7 @@
 
 import ComponentFactory from '@ckeditor/ckeditor5-ui/src/componentfactory';
 import FocusTracker from '@ckeditor/ckeditor5-utils/src/focustracker';
-import { getItemsFromConfig } from '@ckeditor/ckeditor5-ui/src/toolbar/utils';
+import getItemsFromConfig from '@ckeditor/ckeditor5-ui/src/toolbar/getitemsfromconfig';
 
 /**
  * The classic editor UI class.

--- a/src/classiceditorui.js
+++ b/src/classiceditorui.js
@@ -9,7 +9,6 @@
 
 import ComponentFactory from '@ckeditor/ckeditor5-ui/src/componentfactory';
 import FocusTracker from '@ckeditor/ckeditor5-utils/src/focustracker';
-import getItemsFromConfig from '@ckeditor/ckeditor5-ui/src/toolbar/getitemsfromconfig';
 
 /**
  * The classic editor UI class.
@@ -84,7 +83,7 @@ export default class ClassicEditorUI {
 				const promises = [];
 
 				if ( toolbarConfig ) {
-					promises.push( getItemsFromConfig( toolbarConfig, this.view.toolbar.items, this.componentFactory ) );
+					promises.push( this.view.toolbar.fillFromConfig( toolbarConfig, this.componentFactory ) );
 				}
 
 				return Promise.all( promises );

--- a/src/classiceditorui.js
+++ b/src/classiceditorui.js
@@ -9,6 +9,7 @@
 
 import ComponentFactory from '@ckeditor/ckeditor5-ui/src/componentfactory';
 import FocusTracker from '@ckeditor/ckeditor5-utils/src/focustracker';
+import { getItemsFromConfig } from '@ckeditor/ckeditor5-ui/src/toolbar/utils';
 
 /**
  * The classic editor UI class.
@@ -83,9 +84,7 @@ export default class ClassicEditorUI {
 				const promises = [];
 
 				if ( toolbarConfig ) {
-					for ( let name of toolbarConfig ) {
-						promises.push( this.view.toolbar.items.add( this.componentFactory.create( name ) ) );
-					}
+					promises.push( getItemsFromConfig( toolbarConfig, this.view.toolbar.items, this.componentFactory ) );
 				}
 
 				return Promise.all( promises );


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Other: Used `getItemsFromConfig` to bootstrap the toolbar in `ClassicEditorUI`. Closes #51.

---

### Additional information

* Requires https://github.com/ckeditor/ckeditor5-ui/pull/160
