### PR TITLE
T/53: Cannot inherit from ClassicEditor

### DIFF
--- a/src/classic.js
+++ b/src/classic.js
@@ -81,7 +81,7 @@ export default class ClassicEditor extends StandardEditor {
 	 */
 	static create( element, config ) {
 		return new Promise( ( resolve ) => {
-			const editor = new ClassicEditor( element, config );
+			const editor = new this( element, config );
 
 			resolve(
 				editor.initPlugins()

--- a/tests/classic.js
+++ b/tests/classic.js
@@ -87,6 +87,22 @@ describe( 'ClassicEditor', () => {
 		it( 'loads data from the editor element', () => {
 			expect( editor.getData() ).to.equal( '<p><strong>foo</strong> bar</p>' );
 		} );
+
+		it( 'creates an instance of a ClassicEditor child class', () => {
+			class CustomClassicEditor extends ClassicEditor {}
+
+			return CustomClassicEditor.create( editorElement, {
+					plugins: [ Paragraph, Bold ]
+				} )
+				.then( newEditor => {
+					editor = newEditor;
+
+					expect( newEditor ).to.be.instanceof( CustomClassicEditor );
+					expect( newEditor ).to.be.instanceof( ClassicEditor );
+
+					expect( newEditor.getData() ).to.equal( '<p><strong>foo</strong> bar</p>' );
+				} );
+		} );
 	} );
 
 	describe( 'create - events', () => {


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Fix: Allows inheriting from ClassicEditor. Closes #53.

It wasn't able because the `ClassicEditor` was hardcoded in the `create()` method. 