### PR TITLE
t/62: The toolbar should never hide underneath the edited content

### DIFF
--- a/theme/theme.scss
+++ b/theme/theme.scss
@@ -16,6 +16,9 @@
 			border-top: 0;
 			border-left: 0;
 			border-right: 0;
+
+			// https://github.com/ckeditor/ckeditor5-editor-classic/issues/62
+			z-index: ck-z( 'modal' );
 		}
 	}
 


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Fix: The toolbar should never hide underneath the edited content. Closes #62. Closes ckeditor/ckeditor5-upload/issues/33.

---

### Additional information

* Also closes https://github.com/ckeditor/ckeditor5-upload/issues/33.
