### PR TITLE
RootEditableElement is created together with the editor structure.

### DIFF
--- a/src/classiceditorui.js
+++ b/src/classiceditorui.js
@@ -52,6 +52,10 @@ export default class ClassicEditorUI {
 		 * @private
 		 */
 		this._toolbarConfig = normalizeToolbarConfig( editor.config.get( 'toolbar' ) );
+
+		// RootEditableElement should be created together with the editor structure.
+		// See https://github.com/ckeditor/ckeditor5/issues/647.
+		editor.editing.createRoot( 'div' );
 	}
 
 	/**
@@ -72,7 +76,7 @@ export default class ClassicEditorUI {
 		}
 
 		// Setup the editable.
-		const editingRoot = editor.editing.createRoot( 'div' );
+		const editingRoot = editor.editing.view.getRoot();
 		view.editable.bind( 'isReadOnly' ).to( editingRoot );
 		view.editable.bind( 'isFocused' ).to( editor.editing.view );
 		view.editable.name = editingRoot.rootName;

--- a/tests/classiceditorui.js
+++ b/tests/classiceditorui.js
@@ -7,6 +7,7 @@
 
 import ComponentFactory from '@ckeditor/ckeditor5-ui/src/componentfactory';
 import View from '@ckeditor/ckeditor5-ui/src/view';
+import RootEditableElement from '@ckeditor/ckeditor5-engine/src/view/rooteditableelement';
 
 import VirtualTestEditor from '@ckeditor/ckeditor5-core/tests/_utils/virtualtesteditor';
 import ClassicEditorUI from '../src/classiceditorui';
@@ -55,6 +56,10 @@ describe( 'ClassicEditorUI', () => {
 
 		it( 'creates #focusTracker', () => {
 			expect( ui.focusTracker ).to.be.instanceOf( FocusTracker );
+		} );
+
+		it( 'creates root editable element', () => {
+			expect( editor.editing.view.getRoot() ).to.be.instanceOf( RootEditableElement );
 		} );
 	} );
 


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Internal: `RootEditableElement` is created together with the editor structure. Closes https://github.com/ckeditor/ckeditor5/issues/647.