### PR TITLE
Removed `.ck-editor-toolbar` class in ToolbarView

### DIFF
--- a/src/classiceditoruiview.js
+++ b/src/classiceditoruiview.js
@@ -46,12 +46,6 @@ export default class ClassicEditorUIView extends BoxedEditorUIView {
 		 */
 		this.toolbar = new ToolbarView( locale );
 
-		this.toolbar.extendTemplate( {
-			attributes: {
-				class: 'ck-editor-toolbar'
-			}
-		} );
-
 		/**
 		 * Editable UI view.
 		 *

--- a/tests/classiceditoruiview.js
+++ b/tests/classiceditoruiview.js
@@ -44,10 +44,6 @@ describe( 'ClassicEditorUIView', () => {
 				expect( view.toolbar ).to.be.instanceof( ToolbarView );
 			} );
 
-			it( 'is given the right CSS class', () => {
-				expect( view.toolbar.element.classList.contains( 'ck-editor-toolbar' ) ).to.be.true;
-			} );
-
 			it( 'is given a locate object', () => {
 				expect( view.toolbar.locale ).to.equal( locale );
 			} );


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

BREAKING CHANGE:  Removed `.ck-editor-toolbar` class in `ToolbarView`.

---

### Additional information

* A piece of https://github.com/ckeditor/ckeditor5-theme-lark/issues/135
