### PR TITLE
Allow to pass initial data to the editor constructor

### DIFF
--- a/src/classiceditor.js
+++ b/src/classiceditor.js
@@ -54,9 +54,8 @@ export default class ClassicEditor extends Editor {
 	 * {@link module:editor-classic/classiceditor~ClassicEditor.create `ClassicEditor.create()`} method instead.
 	 *
 	 * @protected
-	 * @param {HTMLElement} elementOrData The DOM element that will be the source for the created editor.
-	 * The data will be loaded from it and loaded back to it once the editor is destroyed. If data is provided, `editor.element`
-	 * should be added manually to the DOM after the editor is initialized.  For more information see
+	 * @param {HTMLElement|String} elementOrData The DOM element that will be the source for the created editor
+	 * or editor's initial data. For more information see
 	 * {@link module:editor-classic/classiceditor~ClassicEditor.create `ClassicEditor.create()`}.
 	 * @param {module:core/editor/editorconfig~EditorConfig} config The editor configuration.
 	 */
@@ -133,7 +132,7 @@ export default class ClassicEditor extends Editor {
 	 *				console.error( err.stack );
 	 *			} );
 	 *
-	 * Creating instance when using initial data instead of DOM element:
+	 * Creating instance when using initial data instead of a DOM element:
 	 *
 	 *		import ClassicEditor from '@ckeditor/ckeditor5-editor-classic/src/classiceditor';
 	 *		import Essentials from '@ckeditor/ckeditor5-essentials/src/essentials';
@@ -156,8 +155,22 @@ export default class ClassicEditor extends Editor {
 	 *				console.error( err.stack );
 	 *			} );
 	 *
-	 * @param {HTMLElement} element The DOM element that will be the source for the created editor.
-	 * The data will be loaded from it and loaded back to it once the editor is destroyed.
+	 * @param {HTMLElement|String} elementOrData The DOM element that will be the source for the created editor
+	 * or editor's initial data.
+	 *
+	 * If an element is passed, then it contents will be automatically
+	 * {@link module:editor-classic/classiceditor~ClassicEditor#setData loaded} to the editor on startup
+	 * and  the editor element will replace the passed element in the DOM (the original one will be hidden and editor
+	 * will be injected next to it).
+	 *
+	 * Moreover, the data will be set back to the original element once the editor is destroyed and
+	 * (if the element is a `<textarea>`) when a form in which this element is contained is submitted (which ensures
+	 * automatic integration with native web forms).
+	 *
+	 * If a data is passed, a detached editor will be created. It means that you need to insert it into the DOM manually
+	 * (by accessing the {@link module:editor-classic/classiceditor~ClassicEditor#element `editor.element`} property).
+	 *
+	 * See the examples above to learn more.
 	 * @param {module:core/editor/editorconfig~EditorConfig} config The editor configuration.
 	 * @returns {Promise} A promise resolved once the editor is ready.
 	 * The promise returns the created {@link module:editor-classic/classiceditor~ClassicEditor} instance.

--- a/src/classiceditor.js
+++ b/src/classiceditor.js
@@ -84,9 +84,7 @@ export default class ClassicEditor extends Editor {
 	}
 
 	/**
-	 * An HTML element that represents the whole editor (with UI). See the {@link module:core/editor/editorwithui~EditorWithUI} interface.
-	 *
-	 * @returns {HTMLElement|null}
+	 * @inheritDoc
 	 */
 	get element() {
 		return this.ui.view.element;
@@ -100,7 +98,10 @@ export default class ClassicEditor extends Editor {
 	 * @returns {Promise}
 	 */
 	destroy() {
-		this.updateSourceElement();
+		if ( this.sourceElement ) {
+			this.updateSourceElement();
+		}
+
 		this._elementReplacer.restore();
 		this.ui.destroy();
 
@@ -193,19 +194,16 @@ export default class ClassicEditor extends Editor {
 					.then( () => editor.ui.init() )
 					.then( () => {
 						if ( isElement( sourceElementOrData ) ) {
-							editor._elementReplacer.replace( sourceElementOrData, editor.ui.view.element );
+							editor._elementReplacer.replace( sourceElementOrData, editor.element );
 						}
 
 						editor.fire( 'uiReady' );
 					} )
 					.then( () => editor.editing.view.attachDomRoot( editor.ui.view.editableElement ) )
 					.then( () => {
-						if ( editor.sourceElement ) {
-							editor.data.init( getDataFromElement( editor.sourceElement ) );
-						} else {
-							editor.data.init( sourceElementOrData );
-							editor.sourceElement = editor.ui.view.element;
-						}
+						editor.data.init(
+							isElement( sourceElementOrData ) ? getDataFromElement( sourceElementOrData ) : sourceElementOrData
+						);
 					} )
 					.then( () => {
 						editor.fire( 'dataReady' );

--- a/src/classiceditor.js
+++ b/src/classiceditor.js
@@ -201,9 +201,11 @@ export default class ClassicEditor extends Editor {
 					} )
 					.then( () => editor.editing.view.attachDomRoot( editor.ui.view.editableElement ) )
 					.then( () => {
-						const data = isElement( sourceElementOrData ) ? getDataFromElement( sourceElementOrData ) : sourceElementOrData;
+						const initialData = isElement( sourceElementOrData ) ?
+							getDataFromElement( sourceElementOrData ) :
+							sourceElementOrData;
 
-						return editor.data.init( data );
+						return editor.data.init( initialData );
 					} )
 					.then( () => {
 						editor.fire( 'dataReady' );

--- a/src/classiceditor.js
+++ b/src/classiceditor.js
@@ -54,20 +54,20 @@ export default class ClassicEditor extends Editor {
 	 * {@link module:editor-classic/classiceditor~ClassicEditor.create `ClassicEditor.create()`} method instead.
 	 *
 	 * @protected
-	 * @param {HTMLElement|String} elementOrData The DOM element that will be the source for the created editor
+	 * @param {HTMLElement|String} sourceElementOrData The DOM element that will be the source for the created editor
 	 * or editor's initial data. For more information see
 	 * {@link module:editor-classic/classiceditor~ClassicEditor.create `ClassicEditor.create()`}.
 	 * @param {module:core/editor/editorconfig~EditorConfig} config The editor configuration.
 	 */
-	constructor( elementOrData, config ) {
+	constructor( sourceElementOrData, config ) {
 		super( config );
 
-		if ( isElement( elementOrData ) ) {
-			this.element = elementOrData;
+		if ( isElement( sourceElementOrData ) ) {
+			this.sourceElement = sourceElementOrData;
 		}
 
 		/**
-		 * The element replacer instance used to hide the editor element.
+		 * The element replacer instance used to hide the editor source element.
 		 *
 		 * @protected
 		 * @member {module:utils/elementreplacer~ElementReplacer}
@@ -84,14 +84,23 @@ export default class ClassicEditor extends Editor {
 	}
 
 	/**
+	 * An HTML element that represents the whole editor (with UI). See the {@link module:core/editor/editorwithui~EditorWithUI} interface.
+	 *
+	 * @returns {HTMLElement|null}
+	 */
+	get element() {
+		return this.ui.view.element;
+	}
+
+	/**
 	 * Destroys the editor instance, releasing all resources used by it.
 	 *
-	 * Updates the original editor element with the data.
+	 * Updates the source editor element with the data.
 	 *
 	 * @returns {Promise}
 	 */
 	destroy() {
-		this.updateElement();
+		this.updateSourceElement();
 		this._elementReplacer.restore();
 		this.ui.destroy();
 
@@ -155,15 +164,15 @@ export default class ClassicEditor extends Editor {
 	 *				console.error( err.stack );
 	 *			} );
 	 *
-	 * @param {HTMLElement|String} elementOrData The DOM element that will be the source for the created editor
+	 * @param {HTMLElement|String} sourceElementOrData The DOM element that will be the source for the created editor
 	 * or editor's initial data.
 	 *
-	 * If an element is passed, then it contents will be automatically
+	 * If an element is passed, then its contents will be automatically
 	 * {@link module:editor-classic/classiceditor~ClassicEditor#setData loaded} to the editor on startup
-	 * and  the editor element will replace the passed element in the DOM (the original one will be hidden and editor
-	 * will be injected next to it).
+	 * and the {@link module:core/editor/editorwithui~EditorWithUI#element editor element} will replace the passed element in the DOM
+	 * (the original one will be hidden and editor will be injected next to it).
 	 *
-	 * Moreover, the data will be set back to the original element once the editor is destroyed and
+	 * Moreover, the data will be set back to the source element once the editor is destroyed and
 	 * (if the element is a `<textarea>`) when a form in which this element is contained is submitted (which ensures
 	 * automatic integration with native web forms).
 	 *
@@ -175,27 +184,27 @@ export default class ClassicEditor extends Editor {
 	 * @returns {Promise} A promise resolved once the editor is ready.
 	 * The promise returns the created {@link module:editor-classic/classiceditor~ClassicEditor} instance.
 	 */
-	static create( elementOrData, config ) {
+	static create( sourceElementOrData, config ) {
 		return new Promise( resolve => {
-			const editor = new this( elementOrData, config );
+			const editor = new this( sourceElementOrData, config );
 
 			resolve(
 				editor.initPlugins()
 					.then( () => editor.ui.init() )
 					.then( () => {
-						if ( isElement( elementOrData ) ) {
-							editor._elementReplacer.replace( elementOrData, editor.ui.view.element );
+						if ( isElement( sourceElementOrData ) ) {
+							editor._elementReplacer.replace( sourceElementOrData, editor.ui.view.element );
 						}
 
 						editor.fire( 'uiReady' );
 					} )
 					.then( () => editor.editing.view.attachDomRoot( editor.ui.view.editableElement ) )
 					.then( () => {
-						if ( editor.element ) {
-							editor.data.init( getDataFromElement( editor.element ) );
+						if ( editor.sourceElement ) {
+							editor.data.init( getDataFromElement( editor.sourceElement ) );
 						} else {
-							editor.data.init( elementOrData );
-							editor.element = editor.ui.view.element;
+							editor.data.init( sourceElementOrData );
+							editor.sourceElement = editor.ui.view.element;
 						}
 					} )
 					.then( () => {

--- a/src/classiceditor.js
+++ b/src/classiceditor.js
@@ -54,8 +54,10 @@ export default class ClassicEditor extends Editor {
 	 * {@link module:editor-classic/classiceditor~ClassicEditor.create `ClassicEditor.create()`} method instead.
 	 *
 	 * @protected
-	 * @param {HTMLElement} element The DOM element that will be the source for the created editor.
-	 * The data will be loaded from it and loaded back to it once the editor is destroyed.
+	 * @param {HTMLElement} elementOrData The DOM element that will be the source for the created editor.
+	 * The data will be loaded from it and loaded back to it once the editor is destroyed. If data is provided, `editor.element`
+	 * should be added manually to the DOM after the editor is initialized.  For more information see
+	 * {@link module:editor-classic/classiceditor~ClassicEditor.create `ClassicEditor.create()`}.
 	 * @param {module:core/editor/editorconfig~EditorConfig} config The editor configuration.
 	 */
 	constructor( elementOrData, config ) {
@@ -126,6 +128,29 @@ export default class ClassicEditor extends Editor {
 	 *			} )
 	 *			.then( editor => {
 	 *				console.log( 'Editor was initialized', editor );
+	 *			} )
+	 *			.catch( err => {
+	 *				console.error( err.stack );
+	 *			} );
+	 *
+	 * Creating instance when using initial data instead of DOM element:
+	 *
+	 *		import ClassicEditor from '@ckeditor/ckeditor5-editor-classic/src/classiceditor';
+	 *		import Essentials from '@ckeditor/ckeditor5-essentials/src/essentials';
+	 *		import Bold from '@ckeditor/ckeditor5-basic-styles/src/bold';
+	 *		import Italic from '@ckeditor/ckeditor5-basic-styles/src/italic';
+	 *		import ...
+	 *
+	 *		ClassicEditor
+	 *			.create( '<p>Hello world!</p>', {
+	 *				plugins: [ Essentials, Bold, Italic, ... ],
+	 *				toolbar: [ 'bold', 'italic', ... ]
+	 *			} )
+	 *			.then( editor => {
+	 *				console.log( 'Editor was initialized', editor );
+	 *
+	 *				// Initial data was provided so `editor.element` needs to be added manually to the DOM.
+	 *				document.body.appendChild( editor.element );
 	 *			} )
 	 *			.catch( err => {
 	 *				console.error( err.stack );

--- a/src/classiceditor.js
+++ b/src/classiceditor.js
@@ -201,9 +201,9 @@ export default class ClassicEditor extends Editor {
 					} )
 					.then( () => editor.editing.view.attachDomRoot( editor.ui.view.editableElement ) )
 					.then( () => {
-						editor.data.init(
-							isElement( sourceElementOrData ) ? getDataFromElement( sourceElementOrData ) : sourceElementOrData
-						);
+						const data = isElement( sourceElementOrData ) ? getDataFromElement( sourceElementOrData ) : sourceElementOrData;
+
+						return editor.data.init( data );
 					} )
 					.then( () => {
 						editor.fire( 'dataReady' );

--- a/src/classiceditor.js
+++ b/src/classiceditor.js
@@ -67,7 +67,7 @@ export default class ClassicEditor extends Editor {
 		}
 
 		/**
-		 * The element replacer instance used to hide the editor source element.
+		 * The element replacer instance used to hide the editor's source element.
 		 *
 		 * @protected
 		 * @member {module:utils/elementreplacer~ElementReplacer}
@@ -93,7 +93,7 @@ export default class ClassicEditor extends Editor {
 	/**
 	 * Destroys the editor instance, releasing all resources used by it.
 	 *
-	 * Updates the source editor element with the data.
+	 * Updates the editor's source element with the data.
 	 *
 	 * @returns {Promise}
 	 */
@@ -168,7 +168,7 @@ export default class ClassicEditor extends Editor {
 	 * @param {HTMLElement|String} sourceElementOrData The DOM element that will be the source for the created editor
 	 * or editor's initial data.
 	 *
-	 * If an element is passed, then its contents will be automatically
+	 * If a source element is passed, then its contents will be automatically
 	 * {@link module:editor-classic/classiceditor~ClassicEditor#setData loaded} to the editor on startup
 	 * and the {@link module:core/editor/editorwithui~EditorWithUI#element editor element} will replace the passed element in the DOM
 	 * (the original one will be hidden and editor will be injected next to it).
@@ -181,6 +181,7 @@ export default class ClassicEditor extends Editor {
 	 * (by accessing the {@link module:editor-classic/classiceditor~ClassicEditor#element `editor.element`} property).
 	 *
 	 * See the examples above to learn more.
+	 *
 	 * @param {module:core/editor/editorconfig~EditorConfig} config The editor configuration.
 	 * @returns {Promise} A promise resolved once the editor is ready.
 	 * The promise returns the created {@link module:editor-classic/classiceditor~ClassicEditor} instance.

--- a/tests/classiceditor.js
+++ b/tests/classiceditor.js
@@ -46,15 +46,19 @@ describe( 'ClassicEditor', () => {
 		} );
 
 		it( 'has a Data Interface', () => {
-			testUtils.isMixed( ClassicEditor, DataApiMixin );
+			expect( testUtils.isMixed( ClassicEditor, DataApiMixin ) ).to.true;
 		} );
 
 		it( 'has a Element Interface', () => {
-			testUtils.isMixed( ClassicEditor, ElementApiMixin );
+			expect( testUtils.isMixed( ClassicEditor, ElementApiMixin ) ).to.true;
 		} );
 
 		it( 'creates main root element', () => {
 			expect( editor.model.document.getRoot( 'main' ) ).to.instanceof( RootElement );
+		} );
+
+		it( 'contains the source element as #sourceElement property', () => {
+			expect( editor.sourceElement ).to.equal( editorElement );
 		} );
 
 		it( 'handles form element', () => {
@@ -260,11 +264,11 @@ describe( 'ClassicEditor', () => {
 		} );
 
 		it( 'restores the editor element', () => {
-			expect( editor.element.style.display ).to.equal( 'none' );
+			expect( editor.sourceElement.style.display ).to.equal( 'none' );
 
 			return editor.destroy()
 				.then( () => {
-					expect( editor.element.style.display ).to.equal( '' );
+					expect( editor.sourceElement.style.display ).to.equal( '' );
 				} );
 		} );
 	} );

--- a/tests/classiceditor.js
+++ b/tests/classiceditor.js
@@ -88,6 +88,22 @@ describe( 'ClassicEditor', () => {
 			} );
 		} );
 
+		it( 'allows to pass data to the constructor', () => {
+			return ClassicEditor.create( '<p>Hello world!</p>', {
+				plugins: [ Paragraph ]
+			} ).then( editor => {
+				expect( editor.getData() ).to.equal( '<p>Hello world!</p>' );
+			} );
+		} );
+
+		it( 'editor.element should be equal to editor.ui.view.element when data is passed', () => {
+			return ClassicEditor.create( '<p>Hello world!</p>', {
+				plugins: [ Paragraph ]
+			} ).then( editor => {
+				expect( editor.element ).to.equal( editor.ui.view.element );
+			} );
+		} );
+
 		describe( 'ui', () => {
 			it( 'creates the UI using BoxedEditorUI classes', () => {
 				expect( editor.ui ).to.be.instanceof( ClassicEditorUI );

--- a/tests/classiceditor.js
+++ b/tests/classiceditor.js
@@ -100,14 +100,6 @@ describe( 'ClassicEditor', () => {
 			} );
 		} );
 
-		it( 'editor.element should be equal to editor.ui.view.element when data is passed', () => {
-			return ClassicEditor.create( '<p>Hello world!</p>', {
-				plugins: [ Paragraph ]
-			} ).then( editor => {
-				expect( editor.element ).to.equal( editor.ui.view.element );
-			} );
-		} );
-
 		describe( 'ui', () => {
 			it( 'creates the UI using BoxedEditorUI classes', () => {
 				expect( editor.ui ).to.be.instanceof( ClassicEditorUI );
@@ -157,6 +149,18 @@ describe( 'ClassicEditor', () => {
 				} );
 		} );
 
+		it( 'should have undefined the #sourceElement if editor was initialized with data', () => {
+			return ClassicEditor
+				.create( '<p>Foo.</p>', {
+					plugins: [ Paragraph, Bold ]
+				} )
+				.then( newEditor => {
+					expect( newEditor.sourceElement ).to.be.undefined;
+
+					return newEditor.destroy();
+				} );
+		} );
+
 		describe( 'ui', () => {
 			it( 'inserts editor UI next to editor element', () => {
 				expect( editor.ui.view.element.previousSibling ).to.equal( editorElement );
@@ -164,6 +168,20 @@ describe( 'ClassicEditor', () => {
 
 			it( 'attaches editable UI as view\'s DOM root', () => {
 				expect( editor.editing.view.getDomRoot() ).to.equal( editor.ui.view.editable.element );
+			} );
+
+			it( 'editor.element points to the editor\'s UI when editor was initialized on the DOM element', () => {
+				expect( editor.element ).to.equal( editor.ui.view.element );
+			} );
+
+			it( 'editor.element points to the editor\'s UI when editor was initialized with data', () => {
+				return ClassicEditor.create( '<p>Hello world!</p>', {
+					plugins: [ Paragraph ]
+				} ).then( editor => {
+					expect( editor.element ).to.equal( editor.ui.view.element );
+
+					return editor.destroy();
+				} );
 			} );
 		} );
 	} );
@@ -260,6 +278,23 @@ describe( 'ClassicEditor', () => {
 			return editor.destroy()
 				.then( () => {
 					expect( editorElement.innerHTML ).to.equal( '<p>foo</p>' );
+				} );
+		} );
+
+		it( 'does not update the source element if editor was initialized with data', () => {
+			return ClassicEditor
+				.create( '<p>Foo.</p>', {
+					plugins: [ Paragraph, Bold ]
+				} )
+				.then( newEditor => {
+					const spy = sinon.stub( newEditor, 'updateSourceElement' );
+
+					return newEditor.destroy()
+						.then( () => {
+							expect( spy.called ).to.be.false;
+
+							spy.restore();
+						} );
 				} );
 		} );
 

--- a/tests/manual/classiceditor-data.html
+++ b/tests/manual/classiceditor-data.html
@@ -1,0 +1,18 @@
+<p>
+	<button id="destroyEditor">Destroy editor</button>
+	<button id="initEditor">Init editor</button>
+</p>
+
+<style>
+	body {
+		width: 10000px;
+		height: 10000px;
+	}
+
+	.ck-editor {
+		margin-top: 200px;
+		margin-left: 100px;
+		margin-bottom: 200px;
+		width: 450px;
+	}
+</style>

--- a/tests/manual/classiceditor-data.html
+++ b/tests/manual/classiceditor-data.html
@@ -8,11 +8,4 @@
 		width: 10000px;
 		height: 10000px;
 	}
-
-	.ck-editor {
-		margin-top: 200px;
-		margin-left: 100px;
-		margin-bottom: 200px;
-		width: 450px;
-	}
 </style>

--- a/tests/manual/classiceditor-data.html
+++ b/tests/manual/classiceditor-data.html
@@ -3,9 +3,16 @@
 	<button id="initEditor">Init editor</button>
 </p>
 
+<div class="container"></div>
+
 <style>
 	body {
 		width: 10000px;
 		height: 10000px;
+	}
+
+	.container {
+		padding: 20px;
+		width: 500px;
 	}
 </style>

--- a/tests/manual/classiceditor-data.html
+++ b/tests/manual/classiceditor-data.html
@@ -1,5 +1,5 @@
 <p>
-	<button id="destroyEditor">Destroy editor</button>
+	<button id="destroyEditors">Destroy editors</button>
 	<button id="initEditor">Init editor</button>
 </p>
 

--- a/tests/manual/classiceditor-data.js
+++ b/tests/manual/classiceditor-data.js
@@ -18,6 +18,8 @@ const data = '<h2>Hello world!</h2><p>This is an editor instance.</p>';
 
 window.editors = [];
 
+const container = document.querySelector( '.container' );
+
 function initEditor() {
 	ClassicEditor
 		.create( data, {
@@ -26,7 +28,7 @@ function initEditor() {
 		} )
 		.then( editor => {
 			window.editors.push( editor );
-			document.body.appendChild( editor.element );
+			container.appendChild( editor.element );
 		} )
 		.catch( err => {
 			console.error( err.stack );

--- a/tests/manual/classiceditor-data.js
+++ b/tests/manual/classiceditor-data.js
@@ -1,0 +1,60 @@
+/**
+ * @license Copyright (c) 2003-2018, CKSource - Frederico Knabben. All rights reserved.
+ * For licensing, see LICENSE.md.
+ */
+
+/* globals console:false, document, window */
+
+import ClassicEditor from '../../src/classiceditor';
+import Enter from '@ckeditor/ckeditor5-enter/src/enter';
+import Typing from '@ckeditor/ckeditor5-typing/src/typing';
+import Heading from '@ckeditor/ckeditor5-heading/src/heading';
+import Paragraph from '@ckeditor/ckeditor5-paragraph/src/paragraph';
+import Undo from '@ckeditor/ckeditor5-undo/src/undo';
+import Bold from '@ckeditor/ckeditor5-basic-styles/src/bold';
+import Italic from '@ckeditor/ckeditor5-basic-styles/src/italic';
+import testUtils from '@ckeditor/ckeditor5-utils/tests/_utils/utils';
+
+let editor, editable, observer;
+
+const data = '<h2>Hello world!</h2><p>This is an editor instance.</p>';
+
+function initEditor() {
+	ClassicEditor
+		.create( data, {
+			plugins: [ Enter, Typing, Paragraph, Undo, Heading, Bold, Italic ],
+			toolbar: [ 'heading', '|', 'bold', 'italic', 'undo', 'redo' ]
+		} )
+		.then( newEditor => {
+			console.log( 'Editor was initialized', newEditor );
+			console.log( 'You can now play with it using global `editor` and `editable` variables.' );
+
+			window.editor = editor = newEditor;
+			window.editable = editable = editor.editing.view.document.getRoot();
+
+			observer = testUtils.createObserver();
+			observer.observe( 'Editable', editable, [ 'isFocused' ] );
+
+			document.body.appendChild( editor.element );
+		} )
+		.catch( err => {
+			console.error( err.stack );
+		} );
+}
+
+function destroyEditor() {
+	editor.destroy()
+		.then( () => {
+			editor.element.remove();
+
+			window.editor = editor = null;
+			window.editable = editable = null;
+
+			observer.stopListening();
+			observer = null;
+			console.log( 'Editor was destroyed' );
+		} );
+}
+
+document.getElementById( 'initEditor' ).addEventListener( 'click', initEditor );
+document.getElementById( 'destroyEditor' ).addEventListener( 'click', destroyEditor );

--- a/tests/manual/classiceditor-data.js
+++ b/tests/manual/classiceditor-data.js
@@ -13,11 +13,10 @@ import Paragraph from '@ckeditor/ckeditor5-paragraph/src/paragraph';
 import Undo from '@ckeditor/ckeditor5-undo/src/undo';
 import Bold from '@ckeditor/ckeditor5-basic-styles/src/bold';
 import Italic from '@ckeditor/ckeditor5-basic-styles/src/italic';
-import testUtils from '@ckeditor/ckeditor5-utils/tests/_utils/utils';
-
-let editor, editable, observer;
 
 const data = '<h2>Hello world!</h2><p>This is an editor instance.</p>';
+
+window.editors = [];
 
 function initEditor() {
 	ClassicEditor
@@ -25,16 +24,8 @@ function initEditor() {
 			plugins: [ Enter, Typing, Paragraph, Undo, Heading, Bold, Italic ],
 			toolbar: [ 'heading', '|', 'bold', 'italic', 'undo', 'redo' ]
 		} )
-		.then( newEditor => {
-			console.log( 'Editor was initialized', newEditor );
-			console.log( 'You can now play with it using global `editor` and `editable` variables.' );
-
-			window.editor = editor = newEditor;
-			window.editable = editable = editor.editing.view.document.getRoot();
-
-			observer = testUtils.createObserver();
-			observer.observe( 'Editable', editable, [ 'isFocused' ] );
-
+		.then( editor => {
+			window.editors.push( editor );
 			document.body.appendChild( editor.element );
 		} )
 		.catch( err => {
@@ -43,17 +34,12 @@ function initEditor() {
 }
 
 function destroyEditor() {
-	editor.destroy()
-		.then( () => {
-			editor.element.remove();
-
-			window.editor = editor = null;
-			window.editable = editable = null;
-
-			observer.stopListening();
-			observer = null;
-			console.log( 'Editor was destroyed' );
-		} );
+	window.editors.forEach( editor => {
+		editor.destroy()
+			.then( () => {
+				editor.element.remove();
+			} );
+	} );
 }
 
 document.getElementById( 'initEditor' ).addEventListener( 'click', initEditor );

--- a/tests/manual/classiceditor-data.js
+++ b/tests/manual/classiceditor-data.js
@@ -14,19 +14,19 @@ import Undo from '@ckeditor/ckeditor5-undo/src/undo';
 import Bold from '@ckeditor/ckeditor5-basic-styles/src/bold';
 import Italic from '@ckeditor/ckeditor5-basic-styles/src/italic';
 
-const data = '<h2>Hello world!</h2><p>This is an editor instance.</p>';
-
 window.editors = [];
+let counter = 1;
 
 const container = document.querySelector( '.container' );
 
 function initEditor() {
 	ClassicEditor
-		.create( data, {
+		.create( `<h2>Hello world! #${ counter }</h2><p>This is an editor instance.</p>`, {
 			plugins: [ Enter, Typing, Paragraph, Undo, Heading, Bold, Italic ],
 			toolbar: [ 'heading', '|', 'bold', 'italic', 'undo', 'redo' ]
 		} )
 		.then( editor => {
+			counter += 1;
 			window.editors.push( editor );
 			container.appendChild( editor.element );
 		} )
@@ -35,14 +35,16 @@ function initEditor() {
 		} );
 }
 
-function destroyEditor() {
+function destroyEditors() {
 	window.editors.forEach( editor => {
 		editor.destroy()
 			.then( () => {
 				editor.element.remove();
 			} );
 	} );
+	window.editors = [];
+	counter = 1;
 }
 
 document.getElementById( 'initEditor' ).addEventListener( 'click', initEditor );
-document.getElementById( 'destroyEditor' ).addEventListener( 'click', destroyEditor );
+document.getElementById( 'destroyEditors' ).addEventListener( 'click', destroyEditors );

--- a/tests/manual/classiceditor-data.md
+++ b/tests/manual/classiceditor-data.md
@@ -1,0 +1,18 @@
+1. Click "Init editor".
+2. Expected:
+  * Framed editor should be created.
+  * Original element should disappear.
+  * There should be a toolbar with "Bold", "Italic", "Undo" and "Redo" buttons.
+3. Click "Destroy editor".
+4. Expected:
+  * Editor should be destroyed.
+  * Original element should be visible.
+  * The element should contain its data (updated).
+  * The 'ck-body region' should be removed.
+
+## Notes:
+
+* You can play with:
+  * `editable.isReadOnly`,
+* Changes to `editable.isFocused` should be logged to the console.
+* Features should work.

--- a/tests/manual/classiceditor-data.md
+++ b/tests/manual/classiceditor-data.md
@@ -1,3 +1,3 @@
 1. Click "Init editor".
-2. New editor instance should be appended to the document with initial data in it.
+2. New editor instance should be appended to the document with initial data in it. You can create more than one editor.
 3. After clicking "Destroy editor" all editors should be removed from the document.

--- a/tests/manual/classiceditor-data.md
+++ b/tests/manual/classiceditor-data.md
@@ -1,18 +1,3 @@
 1. Click "Init editor".
-2. Expected:
-  * Framed editor should be created.
-  * Original element should disappear.
-  * There should be a toolbar with "Bold", "Italic", "Undo" and "Redo" buttons.
-3. Click "Destroy editor".
-4. Expected:
-  * Editor should be destroyed.
-  * Original element should be visible.
-  * The element should contain its data (updated).
-  * The 'ck-body region' should be removed.
-
-## Notes:
-
-* You can play with:
-  * `editable.isReadOnly`,
-* Changes to `editable.isFocused` should be logged to the console.
-* Features should work.
+2. New editor instance should be appended to the document with initial data in it.
+3. After clicking "Destroy editor" all editors should be removed from the document.

--- a/tests/manual/classiceditor.md
+++ b/tests/manual/classiceditor.md
@@ -1,12 +1,12 @@
 1. Click "Init editor".
 2. Expected:
   * Framed editor should be created.
-  * Original element should disappear.
+  * Source element should disappear.
   * There should be a toolbar with "Bold", "Italic", "Undo" and "Redo" buttons.
 3. Click "Destroy editor".
 4. Expected:
   * Editor should be destroyed.
-  * Original element should be visible.
+  * Source element should be visible.
   * The element should contain its data (updated).
   * The 'ck-body region' should be removed.
 


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Feature: Editor can be created with initial data passed to the constructor. Closes #72.

BREAKING CHANGE: `ClassicEditor#element` is now available as `ClassicEditor#sourceElement`. See ckeditor/ckeditor5-core#64.

Requires: https://github.com/ckeditor/ckeditor5-core/pull/129