### PR TITLE
Adjustments to new `data#ready` event

### DIFF
--- a/src/classiceditor.js
+++ b/src/classiceditor.js
@@ -181,10 +181,7 @@ export default class ClassicEditor extends Editor {
 
 						return editor.data.init( initialData );
 					} )
-					.then( () => {
-						editor.fire( 'dataReady' );
-						editor.fire( 'ready' );
-					} )
+					.then( () => editor.fire( 'ready' ) )
 					.then( () => editor )
 			);
 		} );

--- a/tests/classiceditor.js
+++ b/tests/classiceditor.js
@@ -192,7 +192,6 @@ describe( 'ClassicEditor', () => {
 
 			class EventWatcher extends Plugin {
 				init() {
-					this.editor.plugins.on( 'ready', spy );
 					this.editor.ui.on( 'ready', spy );
 					this.editor.data.on( 'ready', spy );
 					this.editor.on( 'ready', spy );
@@ -205,7 +204,7 @@ describe( 'ClassicEditor', () => {
 				} )
 				.then( newEditor => {
 					expect( fired ).to.deep.equal(
-						[ 'ready-plugincollection', 'ready-classiceditorui', 'ready-datacontroller', 'ready-classiceditor' ] );
+						[ 'ready-classiceditorui', 'ready-datacontroller', 'ready-classiceditor' ] );
 
 					editor = newEditor;
 				} );

--- a/tests/classiceditor.js
+++ b/tests/classiceditor.js
@@ -194,7 +194,7 @@ describe( 'ClassicEditor', () => {
 				init() {
 					this.editor.plugins.on( 'ready', spy );
 					this.editor.ui.on( 'ready', spy );
-					this.editor.on( 'dataReady', spy );
+					this.editor.data.on( 'ready', spy );
 					this.editor.on( 'ready', spy );
 				}
 			}
@@ -205,29 +205,7 @@ describe( 'ClassicEditor', () => {
 				} )
 				.then( newEditor => {
 					expect( fired ).to.deep.equal(
-						[ 'ready-plugincollection', 'ready-classiceditorui', 'dataReady-classiceditor', 'ready-classiceditor' ] );
-
-					editor = newEditor;
-				} );
-		} );
-
-		it( 'fires dataReady once data is loaded', () => {
-			let data;
-
-			class EventWatcher extends Plugin {
-				init() {
-					this.editor.on( 'dataReady', () => {
-						data = this.editor.getData();
-					} );
-				}
-			}
-
-			return ClassicEditor
-				.create( editorElement, {
-					plugins: [ EventWatcher, Paragraph, Bold ]
-				} )
-				.then( newEditor => {
-					expect( data ).to.equal( '<p><strong>foo</strong> bar</p>' );
+						[ 'ready-plugincollection', 'ready-classiceditorui', 'ready-datacontroller', 'ready-classiceditor' ] );
 
 					editor = newEditor;
 				} );

--- a/tests/classiceditor.js
+++ b/tests/classiceditor.js
@@ -187,12 +187,12 @@ describe( 'ClassicEditor', () => {
 			const fired = [];
 
 			function spy( evt ) {
-				fired.push( evt.name );
+				fired.push( `${ evt.name }-${ evt.source.constructor.name.toLowerCase() }` );
 			}
 
 			class EventWatcher extends Plugin {
 				init() {
-					this.editor.on( 'pluginsReady', spy );
+					this.editor.plugins.on( 'ready', spy );
 					this.editor.ui.on( 'ready', spy );
 					this.editor.on( 'dataReady', spy );
 					this.editor.on( 'ready', spy );
@@ -204,7 +204,8 @@ describe( 'ClassicEditor', () => {
 					plugins: [ EventWatcher ]
 				} )
 				.then( newEditor => {
-					expect( fired ).to.deep.equal( [ 'pluginsReady', 'ready', 'dataReady', 'ready' ] );
+					expect( fired ).to.deep.equal(
+						[ 'ready-plugincollection', 'ready-classiceditorui', 'dataReady-classiceditor', 'ready-classiceditor' ] );
 
 					editor = newEditor;
 				} );

--- a/tests/classiceditorui.js
+++ b/tests/classiceditorui.js
@@ -243,7 +243,6 @@ class VirtualClassicTestEditor extends VirtualTestEditor {
 				editor.initPlugins()
 					.then( () => {
 						editor.ui.init();
-						editor.fire( 'dataReady' );
 						editor.fire( 'ready' );
 					} )
 					.then( () => editor )


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Other: Adjustments to new `data#ready` event.

BREAKING CHANGE: The `editor#dataReady` event was removed. The `editor.data#ready` event has been introduced and should be used instead.

---

### Additional information

See https://github.com/ckeditor/ckeditor5/issues/1477.
