### PR TITLE
i/6220: The main toolbar should always stay on top of contextual UI elements

### DIFF
--- a/theme/classiceditor.css
+++ b/theme/classiceditor.css
@@ -11,6 +11,9 @@
 
 	& .ck-editor__top .ck-sticky-panel .ck-toolbar {
 		/* https://github.com/ckeditor/ckeditor5-editor-classic/issues/62 */
-		z-index: var(--ck-z-modal);
+		/* https://github.com/ckeditor/ckeditor5/issues/6220 */
+		z-index: calc(var(--ck-z-modal) + 1);
+
+		position: relative;
 	}
 }


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Fix: The main toolbar should always stay on top of contextual UI elements. Closes ckeditor/ckeditor5#6220.

---

### Additional information

This issue is not special characters-specific (but any dropdown in the toolbar) and concerns ckeditor5-editor-classic only (checked other editors).
