### PR TITLE
Revert "i/6220: The main toolbar should always stay on top of contextual UI elements"

### DIFF
--- a/theme/classiceditor.css
+++ b/theme/classiceditor.css
@@ -11,9 +11,6 @@
 
 	& .ck-editor__top .ck-sticky-panel .ck-toolbar {
 		/* https://github.com/ckeditor/ckeditor5-editor-classic/issues/62 */
-		/* https://github.com/ckeditor/ckeditor5/issues/6220 */
-		z-index: calc(var(--ck-z-modal) + 1);
-
-		position: relative;
+		z-index: var(--ck-z-modal);
 	}
 }


### PR DESCRIPTION
Revert: bf805f2 